### PR TITLE
Change "All rights reserved" to "Licensed under the MIT License"

### DIFF
--- a/SwiftThreading/AppDelegate.swift
+++ b/SwiftThreading/AppDelegate.swift
@@ -3,7 +3,7 @@
 //  SwiftThreading
 //
 //  Created by Joshua Smith on 7/5/14.
-//  Copyright (c) 2014 iJoshSmith. All rights reserved.
+//  Copyright (c) 2014 iJoshSmith. Licensed under the MIT License.
 //
 
 import UIKit

--- a/SwiftThreading/Threading.swift
+++ b/SwiftThreading/Threading.swift
@@ -3,7 +3,7 @@
 //  SwiftThreading
 //
 //  Created by Joshua Smith on 7/5/14.
-//  Copyright (c) 2014 iJoshSmith. All rights reserved.
+//  Copyright (c) 2014 iJoshSmith. Licensed under the MIT License.
 //
 
 //

--- a/SwiftThreading/ViewController.swift
+++ b/SwiftThreading/ViewController.swift
@@ -3,7 +3,7 @@
 //  SwiftThreading
 //
 //  Created by Joshua Smith on 7/5/14.
-//  Copyright (c) 2014 iJoshSmith. All rights reserved.
+//  Copyright (c) 2014 iJoshSmith. Licensed under the MIT License.
 //
 
 import UIKit


### PR DESCRIPTION
Just a quick clarification by removing the default license since you clearly intended this code to more accessible than all rights reserved.